### PR TITLE
Support sql time parsing

### DIFF
--- a/civil.go
+++ b/civil.go
@@ -82,6 +82,18 @@ func (d Date) AddDays(n int) Date {
 	return DateOf(d.In(time.UTC).AddDate(0, 0, n))
 }
 
+// AddMonths returns the date that is n months in the future.
+// n can also be negative to go into the past.
+func (d Date) AddMonths(n int) Date {
+	return DateOf(d.In(time.UTC).AddDate(0, n, 0))
+}
+
+// AddYears returns the date that is n years in the future.
+// n can also be negative to go into the past.
+func (d Date) AddYears(n int) Date {
+	return DateOf(d.In(time.UTC).AddDate(n, 0, 0))
+}
+
 // DaysSince returns the signed number of days between the date and s, not including the end day.
 // This is the inverse operation to AddDays.
 func (d Date) DaysSince(s Date) (days int) {

--- a/civil.go
+++ b/civil.go
@@ -45,11 +45,12 @@ func DateOf(t time.Time) Date {
 	return d
 }
 
-const rfc3339Date = "2006-01-02"
+// RFC3339Date is the civil date format of RFC3339
+const RFC3339Date = "2006-01-02"
 
 // ParseDate parses a string in RFC3339 full-date format and returns the date value it represents.
 func ParseDate(s string) (Date, error) {
-	t, err := time.Parse(rfc3339Date, s)
+	t, err := time.Parse(RFC3339Date, s)
 	if err != nil {
 		return Date{}, err
 	}
@@ -159,7 +160,7 @@ func (d *Date) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("Date.MarshalJSON: year '%v' outside of range [0,9999]", y)
 	}
 
-	b := make([]byte, 0, len(rfc3339Date)+2)
+	b := make([]byte, 0, len(RFC3339Date)+2)
 	b = append(b, '"')
 	b = append(b, d.String()...)
 	b = append(b, '"')
@@ -219,7 +220,8 @@ func TimeOf(t time.Time) Time {
 	return tm
 }
 
-const rfc3339Time = "15:04:05.999999999"
+// RFC3339Time is the civil time format of RFC3339
+const RFC3339Time = "15:04:05.999999999"
 
 // ParseTime parses a string and returns the time value it represents.
 // ParseTime accepts an extended form of the RFC3339 partial-time format. After
@@ -227,7 +229,7 @@ const rfc3339Time = "15:04:05.999999999"
 // consisting of a decimal point followed by one to nine decimal digits.
 // (RFC3339 admits only one digit after the decimal point).
 func ParseTime(s string) (Time, error) {
-	t, err := time.Parse(rfc3339Time, s)
+	t, err := time.Parse(RFC3339Time, s)
 	if err != nil {
 		return Time{}, err
 	}
@@ -282,7 +284,7 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements encoding/json Marshaler interface
 func (t *Time) MarshalJSON() ([]byte, error) {
-	b := make([]byte, 0, len(rfc3339Time)+2)
+	b := make([]byte, 0, len(RFC3339Time)+2)
 	b = append(b, '"')
 	b = append(b, t.String()...)
 	b = append(b, '"')
@@ -338,7 +340,8 @@ func DateTimeOf(t time.Time) DateTime {
 	}
 }
 
-const rfc3339DateTime = "2006-01-02T15:04:05.999999999"
+// RFC3339Time is the civil datetime format of RFC3339
+const RFC3339DateTime = "2006-01-02T15:04:05.999999999"
 
 // ParseDateTime parses a string and returns the DateTime it represents.
 // ParseDateTime accepts a variant of the RFC3339 date-time format that omits
@@ -347,7 +350,7 @@ const rfc3339DateTime = "2006-01-02T15:04:05.999999999"
 //     YYYY-MM-DDTHH:MM:SS[.FFFFFFFFF]
 // where the 'T' may be a lower-case 't'.
 func ParseDateTime(s string) (DateTime, error) {
-	t, err := time.Parse(rfc3339DateTime, s)
+	t, err := time.Parse(RFC3339DateTime, s)
 	if err != nil {
 		t, err = time.Parse("2006-01-02t15:04:05.999999999", s)
 		if err != nil {
@@ -369,7 +372,7 @@ func (dt DateTime) IsValid() bool {
 
 // In returns the time corresponding to the DateTime in the given location.
 //
-// If the time is missing or ambigous at the location, In returns the same
+// If the time is missing or ambiguous at the location, In returns the same
 // result as time.Date. For example, if loc is America/Indiana/Vincennes, then
 // both
 //     time.Date(1955, time.May, 1, 0, 30, 0, 0, loc)
@@ -424,7 +427,7 @@ func (dt *DateTime) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements encoding/json Marshaler interface
 func (dt *DateTime) MarshalJSON() ([]byte, error) {
-	b := make([]byte, 0, len(rfc3339DateTime)+2)
+	b := make([]byte, 0, len(RFC3339DateTime)+2)
 	b = append(b, '"')
 	b = append(b, dt.String()...)
 	b = append(b, '"')

--- a/civil.go
+++ b/civil.go
@@ -180,20 +180,21 @@ func (d *Date) Scan(value interface{}) error {
 
 	str, ok := value.(string)
 	if !ok {
-		bytes, ok := value.([]byte)
+		t, ok := value.(time.Time)
 		if !ok {
-			return fmt.Errorf("'%s' could not be converted into a valid string", str)
+			return fmt.Errorf("'%s' could not be converted into a valid type", str)
 		}
 
-		str = string(bytes[:])
+		val := DateOf(t)
+		*d = val
+	} else {
+		val, err := ParseDate(str)
+		if err != nil {
+			return err
+		}
+		*d = val
 	}
 
-	val, err := ParseDate(str)
-	if err != nil {
-		return err
-	}
-
-	*d = val
 	return nil
 }
 
@@ -304,20 +305,21 @@ func (t *Time) Scan(value interface{}) error {
 
 	str, ok := value.(string)
 	if !ok {
-		bytes, ok := value.([]byte)
+		tm, ok := value.(time.Time)
 		if !ok {
-			return fmt.Errorf("'%s' could not be converted into a valid string", str)
+			return fmt.Errorf("'%s' could not be converted into a valid type", str)
 		}
 
-		str = string(bytes[:])
+		val := TimeOf(tm)
+		*t = val
+	} else {
+		val, err := ParseTime(str)
+		if err != nil {
+			return err
+		}
+		*t = val
 	}
 
-	val, err := ParseTime(str)
-	if err != nil {
-		return err
-	}
-
-	*t = val
 	return nil
 }
 
@@ -447,19 +449,20 @@ func (dt *DateTime) Scan(value interface{}) error {
 
 	str, ok := value.(string)
 	if !ok {
-		bytes, ok := value.([]byte)
+		t, ok := value.(time.Time)
 		if !ok {
-			return fmt.Errorf("'%s' could not be converted into a valid string", str)
+			return fmt.Errorf("'%s' could not be converted into a valid type", str)
 		}
 
-		str = string(bytes[:])
+		val := DateTimeOf(t)
+		*dt = val
+	} else {
+		val, err := ParseDateTime(str)
+		if err != nil {
+			return err
+		}
+		*dt = val
 	}
 
-	val, err := ParseDateTime(str)
-	if err != nil {
-		return err
-	}
-
-	*dt = val
 	return nil
 }

--- a/civil_test.go
+++ b/civil_test.go
@@ -1,0 +1,244 @@
+// Copyright 2016 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package civil implements types for civil time, a time-zone-independent
+// representation of time that follows the rules of the proleptic
+// Gregorian calendar with exactly 24-hour days, 60-minute hours, and 60-second
+// minutes.
+//
+// Because they lack location information, these types do not represent unique
+// moments or intervals of time. Use time.Time for that purpose.
+package civil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDate_MarshalJSON(t *testing.T) {
+
+	dLeap := Date{
+		Year:  2020,
+		Month: 2,
+		Day:   29,
+	}
+
+	json, err := dLeap.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`"2020-02-29"`), json)
+
+	dInvalid := Date{
+		Year:  -1,
+		Month: 2,
+		Day:   29,
+	}
+
+	json, err = dInvalid.MarshalJSON()
+	assert.EqualError(t, err, "Date.MarshalJSON: year '-1' outside of range [0,9999]")
+	assert.Nil(t, json)
+}
+
+func TestDate_UnmarshalJSON(t *testing.T) {
+	jsonLeap := []byte(`"2020-02-29"`)
+	dLeap := &Date{}
+	err := dLeap.UnmarshalJSON(jsonLeap)
+	assert.NoError(t, err)
+	assert.Equal(t, Date{Year: 2020, Month: 2, Day: 29}, *dLeap)
+
+	jsonInvalid := []byte(`"2020-13-40"`)
+	dInvalid := &Date{}
+	err = dInvalid.UnmarshalJSON(jsonInvalid)
+	assert.EqualError(t, err, "invalid date: parsing time \"2020-13-40\": month out of range")
+}
+
+func TestDate_AddMonths(t *testing.T) {
+	dLeap := Date{
+		Year:  2020,
+		Month: 2,
+		Day:   29,
+	}
+
+	dLeap = dLeap.AddMonths(12)
+
+	assert.Equal(t, Date{Year: 2021, Month: 3, Day: 1}, dLeap) // no leap day in 2021, so pushes over to 3/1
+}
+
+func TestDate_AddYears(t *testing.T) {
+	dLeap := Date{
+		Year:  2020,
+		Month: 2,
+		Day:   29,
+	}
+
+	dLeap = dLeap.AddYears(1)
+
+	assert.Equal(t, Date{Year: 2021, Month: 3, Day: 1}, dLeap) // no leap day in 2021, so pushes over to 3/1
+}
+
+func TestDate_Value(t *testing.T) {
+	d := Date{
+		Year:  2020,
+		Month: 2,
+		Day:   29,
+	}
+
+	v, err := d.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, v, "2020-02-29")
+}
+
+func TestDate_Scan(t *testing.T) {
+	d := &Date{}
+	var v interface{}
+	v = "2020-02-29"
+	d.Scan(v)
+	assert.Equal(t, Date{Year: 2020, Month: 2, Day: 29}, *d)
+}
+
+func TestTime_MarshalJSON(t *testing.T) {
+
+	time := Time{
+		Hour:       3,
+		Minute:     42,
+		Second:     31,
+		Nanosecond: 876,
+	}
+
+	json, err := time.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`"03:42:31.000000876"`), json)
+}
+
+func TestTime_UnmarshalJSON(t *testing.T) {
+	jsonGood := []byte(`"03:42:31.000000876"`)
+	timeGood := &Time{}
+	err := timeGood.UnmarshalJSON(jsonGood)
+	assert.NoError(t, err)
+	assert.Equal(t, Time{Hour: 3, Minute: 42, Second: 31, Nanosecond: 876}, *timeGood)
+
+	jsonInvalid := []byte(`"-3:42:31.000000876"`)
+	timeInvalid := &Time{}
+	err = timeInvalid.UnmarshalJSON(jsonInvalid)
+	assert.EqualError(t, err, "invalid time: parsing time \"-3:42:31.000000876\" as \"15:04:05.999999999\": cannot parse \"-3:42:31.000000876\" as \"15\"")
+}
+
+func TestTime_Value(t *testing.T) {
+	time := Time{
+		Hour:       3,
+		Minute:     42,
+		Second:     31,
+		Nanosecond: 876,
+	}
+
+	v, err := time.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, "03:42:31.000000876", v)
+}
+
+func TestTime_Scan(t *testing.T) {
+	time := &Time{}
+	var v interface{}
+	v = "03:42:31.000000876"
+	time.Scan(v)
+	assert.Equal(t, *time, Time{Hour: 3, Minute: 42, Second: 31, Nanosecond: 876})
+}
+
+func TestDateTime_MarshalJSON(t *testing.T) {
+
+	datetime := DateTime{
+		Date: Date{
+			Year:  2020,
+			Month: 2,
+			Day:   29,
+		},
+		Time: Time{
+			Hour:       3,
+			Minute:     42,
+			Second:     31,
+			Nanosecond: 876,
+		},
+	}
+
+	json, err := datetime.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`"2020-02-29T03:42:31.000000876"`), json)
+}
+
+func TestDateTime_UnmarshalJSON(t *testing.T) {
+	jsonGood := []byte(`"2020-02-29T03:42:31.000000876"`)
+	datetimeGood := &DateTime{}
+	err := datetimeGood.UnmarshalJSON(jsonGood)
+	assert.NoError(t, err)
+	expectedGood := DateTime{
+		Date: Date{
+			Year:  2020,
+			Month: 2,
+			Day:   29,
+		},
+		Time: Time{
+			Hour:       3,
+			Minute:     42,
+			Second:     31,
+			Nanosecond: 876,
+		},
+	}
+	assert.Equal(t, expectedGood, *datetimeGood)
+
+	jsonInvalid := []byte(`"0-02-29T03:42:31.000000876"`)
+	datetimeInvalid := &DateTime{}
+	err = datetimeInvalid.UnmarshalJSON(jsonInvalid)
+	assert.EqualError(t, err, "invalid datetime: parsing time \"0-02-29T03:42:31.000000876\" as \"2006-01-02t15:04:05.999999999\": cannot parse \"-29T03:42:31.000000876\" as \"2006\"")
+}
+
+func TestDateTime_Value(t *testing.T) {
+	datetime := DateTime{
+		Date: Date{
+			Year:  2020,
+			Month: 2,
+			Day:   29,
+		},
+		Time: Time{
+			Hour:       3,
+			Minute:     42,
+			Second:     31,
+			Nanosecond: 876,
+		},
+	}
+
+	v, err := datetime.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, "2020-02-29T03:42:31.000000876", v)
+}
+
+func TestDateTime_Scan(t *testing.T) {
+	datetime := &DateTime{}
+	var v interface{}
+	v = "2020-02-29T03:42:31.000000876"
+	datetime.Scan(v)
+	expected := DateTime{
+		Date: Date{
+			Year:  2020,
+			Month: 2,
+			Day:   29,
+		},
+		Time: Time{
+			Hour:       3,
+			Minute:     42,
+			Second:     31,
+			Nanosecond: 876,
+		},
+	}
+	assert.Equal(t, *datetime, expected)
+}

--- a/civil_test.go
+++ b/civil_test.go
@@ -23,6 +23,7 @@ package civil
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -99,10 +100,18 @@ func TestDate_Value(t *testing.T) {
 	assert.Equal(t, v, "2020-02-29")
 }
 
-func TestDate_Scan(t *testing.T) {
+func TestDate_Scan_String(t *testing.T) {
 	d := &Date{}
 	var v interface{}
 	v = "2020-02-29"
+	d.Scan(v)
+	assert.Equal(t, Date{Year: 2020, Month: 2, Day: 29}, *d)
+}
+
+func TestDate_Scan_Time(t *testing.T) {
+	d := &Date{}
+	var v interface{}
+	v = time.Date(2020, time.February, 29, 0, 0, 0, 0, time.UTC)
 	d.Scan(v)
 	assert.Equal(t, Date{Year: 2020, Month: 2, Day: 29}, *d)
 }
@@ -147,12 +156,20 @@ func TestTime_Value(t *testing.T) {
 	assert.Equal(t, "03:42:31.000000876", v)
 }
 
-func TestTime_Scan(t *testing.T) {
+func TestTime_Scan_String(t *testing.T) {
 	time := &Time{}
 	var v interface{}
 	v = "03:42:31.000000876"
 	time.Scan(v)
 	assert.Equal(t, *time, Time{Hour: 3, Minute: 42, Second: 31, Nanosecond: 876})
+}
+
+func TestTime_Scan_Time(t *testing.T) {
+	tm := &Time{}
+	var v interface{}
+	v = time.Date(2020, time.February, 29, 3, 42, 31, 876, time.UTC)
+	tm.Scan(v)
+	assert.Equal(t, *tm, Time{Hour: 3, Minute: 42, Second: 31, Nanosecond: 876})
 }
 
 func TestDateTime_MarshalJSON(t *testing.T) {
@@ -222,10 +239,31 @@ func TestDateTime_Value(t *testing.T) {
 	assert.Equal(t, "2020-02-29T03:42:31.000000876", v)
 }
 
-func TestDateTime_Scan(t *testing.T) {
+func TestDateTime_ScanString(t *testing.T) {
 	datetime := &DateTime{}
 	var v interface{}
 	v = "2020-02-29T03:42:31.000000876"
+	datetime.Scan(v)
+	expected := DateTime{
+		Date: Date{
+			Year:  2020,
+			Month: 2,
+			Day:   29,
+		},
+		Time: Time{
+			Hour:       3,
+			Minute:     42,
+			Second:     31,
+			Nanosecond: 876,
+		},
+	}
+	assert.Equal(t, *datetime, expected)
+}
+
+func TestDateTime_Scan(t *testing.T) {
+	datetime := &DateTime{}
+	var v interface{}
+	v = time.Date(2020, time.February, 29, 3, 42, 31, 876, time.UTC)
 	datetime.Scan(v)
 	expected := DateTime{
 		Date: Date{

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/openlyinc/civil
+
+go 1.13
+
+require github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Go SQL parses columns formatted as dates or times into time.Time. This change adds support for converting native time.Time into civil.Date.